### PR TITLE
fix: add missing type definitions from StrUtils.h

### DIFF
--- a/postype.go
+++ b/postype.go
@@ -6,7 +6,7 @@ type POSType string
 
 // NOTE: update isValid function when adding a new POSType.
 const (
-	POS_UNKNOWN POSType = "UNKNOWN"
+	POS_UNKNOWN POSType = "UN"
 
 	POS_NNG POSType = "NNG"
 	POS_NNP POSType = "NNP"
@@ -65,8 +65,6 @@ const (
 	POS_SN  POSType = "SN"
 	POS_SB  POSType = "SB"
 
-	POS_UN POSType = "UN"
-
 	POS_W_URL     POSType = "W_URL"
 	POS_W_EMAIL   POSType = "W_EMAIL"
 	POS_W_HASHTAG POSType = "W_HASHTAG"
@@ -82,6 +80,18 @@ const (
 	POS_USER_2 POSType = "USER2"
 	POS_USER_3 POSType = "USER3"
 	POS_USER_4 POSType = "USER4"
+
+	POS_VV_I  POSType = "VV-I"
+	POS_VA_I  POSType = "VA-I"
+	POS_VX_I  POSType = "VX-I"
+	POS_XSA_I POSType = "XSA-I"
+
+	POS_VV_R  POSType = "VV-R"
+	POS_VA_R  POSType = "VA-R"
+	POS_VX_R  POSType = "VX-R"
+	POS_XSA_R POSType = "XSA-R"
+
+	POS_V POSType = "V"
 )
 
 func (p POSType) isValid() bool {
@@ -134,7 +144,6 @@ func (p POSType) isValid() bool {
 		POS_SH,
 		POS_SN,
 		POS_SB,
-		POS_UN,
 		POS_W_URL,
 		POS_W_EMAIL,
 		POS_W_HASHTAG,
@@ -147,7 +156,16 @@ func (p POSType) isValid() bool {
 		POS_USER_1,
 		POS_USER_2,
 		POS_USER_3,
-		POS_USER_4:
+		POS_USER_4,
+		POS_VV_I,
+		POS_VA_I,
+		POS_VX_I,
+		POS_XSA_I,
+		POS_VV_R,
+		POS_VA_R,
+		POS_VX_R,
+		POS_XSA_R,
+		POS_V:
 		return true
 	default:
 		return false

--- a/postype.go
+++ b/postype.go
@@ -5,6 +5,9 @@ import "fmt"
 type POSType string
 
 // NOTE: update isValid function when adding a new POSType.
+// POS type definitions from Kiwi C++ library:
+// - Type https://github.com/bab2min/Kiwi/blob/18b4062f98cf3beaedac149fc511a2708891f71d/include/kiwi/Types.h#L188-L219
+// - String https://github.com/bab2min/Kiwi/blob/18b4062f98cf3beaedac149fc511a2708891f71d/src/Utils.cpp#L300
 const (
 	POS_UNKNOWN POSType = "UN"
 


### PR DESCRIPTION
안녕하세요

VV, VA, VX, XSA 태그에 불규칙 활용여부를 명시하는 접미사 -R와 -I 덧붙는 부분 누락되어 있어 추가 하였습니다.

반영 부탁드립니다.
감사합니다.