### PR TITLE
ci: status check 이름을 Go 버전과 분리 + 액션 버전업

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,19 +7,17 @@ name: CI
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        go-version:
-          - '1.26'
         os:
           - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - name: Install Go
+        uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
       - run: make install-kiwi
       - run: make test
-


### PR DESCRIPTION
## 배경

PR #43이 "Pending" 상태에서 무기한 막혀 있었습니다. branch protection이 요구하는 status check 이름과 실제 리포트되는 이름이 어긋난 것이 원인이었습니다.

job에 `name:`이 없어서 GitHub이 check 이름을 **job id + matrix 값**으로 자동 생성합니다. matrix가 `go-version` → `os` 순이라 `test (1.26, ubuntu-latest)`가 됩니다. branch protection은 이 문자열을 정확히 일치시키는 방식으로만 동작하고 와일드카드를 지원하지 않아서, **Go 버전을 올릴 때마다 required context가 stale해집니다.** 게다가 요구된 context가 리포트되지 않으면 실패가 아니라 "Expected — Waiting for status to be reported"로 조용히 영구 대기합니다.

## 변경 사항

- **matrix에서 `go-version` 제거, `go-version-file: go.mod` 사용** — check 이름이 `test (ubuntu-latest)` / `test (macos-latest)`가 되어 툴체인 버전과 무관해집니다. `go.mod`에 이미 `go 1.26`이 있어 CI에서 쓰는 Go 버전은 그대로입니다.
- **`checkout`을 `setup-go`보다 먼저 실행** — `go-version-file`은 파일이 체크아웃된 뒤에만 읽을 수 있어서 필수입니다.
- **`fail-fast: false`** — #43 실행 때 macOS 실패로 ubuntu job이 cancelled 되어 한쪽 로그만 볼 수 있었습니다.
- **액션 버전업** — `actions/checkout` v4 → v7, `actions/setup-go` v5 → v7. 두 액션 모두 러너 v2.327.1 이상을 요구하는데 GitHub-hosted 러너는 충족합니다.

aggregate gate job(`ci-ok` 하나만 required로 거는 패턴)도 검토했지만 채택하지 않았습니다. `needs:` 목록을 사람이 관리해야 해서 나중에 job을 추가하고 넣는 걸 잊으면 게이트가 초록인 채로 커버리지가 조용히 새기 때문입니다. job이 늘어나 required 목록 관리가 부담이 되면 그때 재검토하는 게 낫다고 봤습니다.

## ⚠️ 머지 순서

이 PR은 **자기 자신을 정상 경로로 머지할 수 없습니다.** CI가 새 이름으로 리포트되는데 현재 required는 `test (1.26, ...)`라서 stale context에 걸립니다.

1. 아래 CI 결과를 직접 확인 (자동 게이트가 매칭되지 않음)
2. admin bypass로 머지
3. **머지 후 반드시** required context 교체:

```bash
gh api -X PATCH repos/codingpot/kiwigo/branches/main/protection/required_status_checks \
  -f 'checks[][context]=test (ubuntu-latest)' \
  -f 'checks[][context]=test (macos-latest)'
```

3번을 빠뜨리면 required가 `test (1.26, ...)`로 남아 이후 모든 PR이 영구 pending에 걸립니다.

## 확인 사항

- 두 job 모두 통과하고 check 이름이 `test (ubuntu-latest)` / `test (macos-latest)`로 리포트되는지
- "Install Go" step에서 설치된 버전이 `go.mod`의 1.26과 일치하는지 (setup-go v6의 toolchain 처리 변경 영향 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
